### PR TITLE
ENH: ssh/scp data for tcbsd PLCs

### DIFF
--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -20,6 +20,6 @@ jobs:
       # Extras to be installed only for conda-based testing:
       conda-testing-extras: ""
       # Extras to be installed only for pip-based testing:
-      pip-testing-extras: "PyQt5"
+      pip-testing-extras: ""
       # Set if using setuptools-scm for the conda-build workflow
       use-setuptools-scm: true

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,0 +1,43 @@
+{% set package_name = "pmpsdb_client" %}
+{% set import_name = "pmpsdb_client" %}
+{% set version = load_file_regex(load_file=os.path.join(import_name, "_version.py"), regex_pattern=".*version = '(\S+)'").group(1) %}
+
+package:
+  name: {{ package_name }}
+  version : {{ version }}
+
+source:
+  path: ..
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  build:
+    - python >=3.9
+    - pip
+    - setuptools_scm
+  run:
+    - python >=3.9
+    - fabric
+    - ophyd
+    - pcdscalc
+    - pcdsutils
+    - prettytable
+    - qtpy
+  run_constrained:
+    - pyqt =5
+
+test:
+  requires:
+    - pytest
+    - pyqt=5.15
+  imports:
+    - {{ import_name }}
+
+about:
+  home: https://github.com/pcdshub/pcdsdevices
+  license: SLAC Open License
+  summary: IOC definitions for LCLS Beamline Devices

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,3 @@
-pyqt
+PyQt5
 pytest
+setuptools-scm

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,2 @@
+pyqt
 pytest

--- a/pmpsdb_client/cli/__init__.py
+++ b/pmpsdb_client/cli/__init__.py
@@ -53,6 +53,9 @@ def _main(args: argparse.Namespace) -> int:
             level=logging.INFO,
             format='%(levelname)s: %(message)s',
         )
+        # Noisy log messages from ssh transport layer
+        for module in ("fabric", "paramiko", "intake"):
+            logging.getLogger(module).setLevel(logging.WARNING)
     if args.export_dir:
         from ..export_data import set_export_dir
         set_export_dir(args.export_dir)

--- a/pmpsdb_client/cli/__init__.py
+++ b/pmpsdb_client/cli/__init__.py
@@ -47,7 +47,10 @@ def _main(args: argparse.Namespace) -> int:
         print(version)
         return 0
     if args.verbose:
-        logging.basicConfig(level=logging.DEBUG)
+        logging.basicConfig(
+            level=logging.DEBUG,
+            format="%(asctime)s %(levelname)s: %(name)s %(message)s",
+        )
     else:
         logging.basicConfig(
             level=logging.INFO,

--- a/pmpsdb_client/cli/transfer_tools.py
+++ b/pmpsdb_client/cli/transfer_tools.py
@@ -21,16 +21,10 @@ def cli_list_files(args: argparse.Namespace) -> int:
 def _list_files(hostname: str) -> int:
     infos = list_file_info(hostname=hostname)
     for data in infos:
-        try:
-            print(
-                f'{data.filename} uploaded at {data.create_time.ctime()} '
-                f'({data.size} bytes)'
-            )
-        except AttributeError:
-            print(
-                f'{data.filename} uploaded at {data.last_changed.ctime()} '
-                f'({data.size} bytes)'
-            )
+        print(
+            f'{data.filename} uploaded at {data.last_changed.ctime()} '
+            f'({data.size} bytes)'
+        )
     if not infos:
         logger.warning('No files found')
     return 0

--- a/pmpsdb_client/cli/transfer_tools.py
+++ b/pmpsdb_client/cli/transfer_tools.py
@@ -7,7 +7,7 @@ import os.path
 from typing import Optional
 
 from ..export_data import ExportFile, get_latest_exported_files
-from ..ftp_data import (compare_file, download_file_text, list_file_info,
+from ..plc_data import (compare_file, download_file_text, list_file_info,
                         upload_filename)
 
 logger = logging.getLogger(__name__)
@@ -21,10 +21,16 @@ def cli_list_files(args: argparse.Namespace) -> int:
 def _list_files(hostname: str) -> int:
     infos = list_file_info(hostname=hostname)
     for data in infos:
-        print(
-            f'{data.filename} uploaded at {data.create_time.ctime()} '
-            f'({data.size} bytes)'
-        )
+        try:
+            print(
+                f'{data.filename} uploaded at {data.create_time.ctime()} '
+                f'({data.size} bytes)'
+            )
+        except AttributeError:
+            print(
+                f'{data.filename} uploaded at {data.last_changed.ctime()} '
+                f'({data.size} bytes)'
+            )
     if not infos:
         logger.warning('No files found')
     return 0

--- a/pmpsdb_client/data_types.py
+++ b/pmpsdb_client/data_types.py
@@ -10,148 +10,6 @@ to move these files around and compare them to each other.
 """
 import dataclasses
 import datetime
-import enum
-import typing
-
-from pcdscalc.pmps import get_bitmask_desc
-
-from .beam_class import summarize_beam_class_bitmask
-
-# "Raw" data types are the presentation of the data as in the json file.
-# Most beam params are serialized as str, except for id (int) and special (bool)
-RawStateBeamParams = dict[str, typing.Union[str, int, bool]]
-# A bunch of raw beam params are collected by name for one device
-RawDeviceBeamParams = dict[str, RawStateBeamParams]
-# Each device on the plc is collected by name
-RawPLCBeamParams = dict[str, RawDeviceBeamParams]
-# The json file has the plc name at the top level
-RawFileContents = dict[str, RawPLCBeamParams]
-
-T = typing.TypeVar("T")
-
-
-class BPKeys(enum.Enum):
-    """
-    Mapping from user-visible name to database key for beam parameters.
-    """
-    id = "id"
-    name_ = "name"
-    beamline = "beamline"
-    nbc_range = "nBeamClassRange"
-    nev_range = "neVRange"
-    ntran = "nTran"
-    nrate = "nRate"
-    aperture_name = "ap_name"
-    y_gap = "ap_ygap"
-    y_center = "ap_ycenter"
-    x_gap = "ap_xgap"
-    x_center = "ap_xcenter"
-    damage_limit = "damage_limit"
-    pulse_energy = "pulse_energy"
-    notes = "notes"
-    special = "special"
-
-
-@dataclasses.dataclass(frozen=True)
-class BeamParameters:
-    """
-    Struct representation of one state's beam parameters.
-
-    The raw data has most of these as strings, but to make the struct
-    here we'll convert them to the most natural data types for
-    comparisons and add additional helpful fields for
-    human readability.
-
-    The same names as used in the web application are used here,
-    but all lowercase and with spaces replaced with underscores.
-    """
-    id: int
-    name: str
-    beamline: str
-    nbc_range: int
-    nbc_range_mask: str
-    nbc_range_desc: str
-    nev_range: int
-    nev_range_mask: str
-    nev_range_desc: str
-    ntran: float
-    nrate: int
-    aperture_name: str
-    y_gap: float
-    y_center: float
-    x_gap: float
-    x_center: float
-    damage_limit: str
-    pulse_energy: str
-    notes: str
-    special: bool
-
-    @classmethod
-    def from_raw(cls: type[T], data: RawStateBeamParams) -> T:
-        return cls(
-            id=data[BPKeys.id],
-            name=data[BPKeys.name_],
-            beamline=data[BPKeys.beamline],
-            nbc_range=int(data[BPKeys.nbc_range]),
-            nbc_range_mask=data[BPKeys.nbc_range],
-            nbc_range_desc=summarize_beam_class_bitmask(int(data[BPKeys.nbc_range])),
-            nev_range=int(data[BPKeys.nev_range]),
-            nev_range_mask=data[BPKeys.nev_range],
-            nev_range_desc=get_bitmask_desc(data[BPKeys.nev_range]),
-            ntran=float(data[BPKeys.ntran]),
-            aperture_name=data[BPKeys.aperture_name],
-            y_gap=float(data[BPKeys.y_gap]),
-            y_center=float(data[BPKeys.y_center]),
-            x_gap=float(data[BPKeys.x_gap]),
-            x_center=float(data[BPKeys.x_center]),
-            damage_limit=data[BPKeys.damage_limit],
-            pulse_energy=data[BPKeys.pulse_energy],
-            notes=data[BPKeys.notes],
-            special=data[BPKeys.special],
-        )
-
-
-@dataclasses.dataclass(frozen=True)
-class DeviceBeamParams:
-    """
-    The beam parameters associated with one device.
-
-    One device may have an arbitrary number of states.
-    """
-    device_name: str
-    state_beam_params: dict[str, BeamParameters]
-
-    @classmethod
-    def from_raw(cls: type[T], device_name: str, data: RawDeviceBeamParams) -> T:
-        return cls(
-            device_name=device_name,
-            state_beam_params={
-                key: BeamParameters.from_raw(value)
-                for key, value in data.items()
-            }
-        )
-
-
-@dataclasses.dataclass(frozen=True)
-class FileContents:
-    """
-    The contents of one file.
-
-    Each file is associated with exactly one plc hostname
-    and can contain an arbitrary number of devices.
-    """
-    plc_name: str
-    device_beam_params: dict[str, DeviceBeamParams]
-
-    @classmethod
-    def from_raw(cls: type[T], data: RawFileContents) -> T:
-        return cls(
-            plc_name=next(data.keys()),
-            device_beam_params={
-                key: DeviceBeamParams.from_raw(key, value)
-                for key, value in data.items()
-            }
-        )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -159,22 +17,12 @@ class FileInfo:
     """
     Generalized file info.
 
-    The fields are based on *nix systems, but this will
-    also be used for windows systems too.
+    Only contains fields available to both ftp and ssh.
 
     This class has no constructor helpers here.
     Each data source will need to implement a unique
     constructor for this.
     """
     filename: str
-    directory: str
-    server: str
-    is_directory: bool
-    permissions: str
-    links: int
-    user: str
-    group: str
     size: int
     last_changed: datetime.datetime
-    raw_contents: RawFileContents
-    contents: FileContents

--- a/pmpsdb_client/data_types.py
+++ b/pmpsdb_client/data_types.py
@@ -1,0 +1,180 @@
+"""
+This module defines important data structures centrally.
+
+This helps us compare the same kinds of data to each other,
+even when this data comes from different sources.
+
+Note that all the dataclasses are frozen: editing these data
+structures is not in scope for this library, it is only intended
+to move these files around and compare them to each other.
+"""
+import dataclasses
+import datetime
+import enum
+import typing
+
+from pcdscalc.pmps import get_bitmask_desc
+
+from .beam_class import summarize_beam_class_bitmask
+
+# "Raw" data types are the presentation of the data as in the json file.
+# Most beam params are serialized as str, except for id (int) and special (bool)
+RawStateBeamParams = dict[str, typing.Union[str, int, bool]]
+# A bunch of raw beam params are collected by name for one device
+RawDeviceBeamParams = dict[str, RawStateBeamParams]
+# Each device on the plc is collected by name
+RawPLCBeamParams = dict[str, RawDeviceBeamParams]
+# The json file has the plc name at the top level
+RawFileContents = dict[str, RawPLCBeamParams]
+
+T = typing.TypeVar("T")
+
+
+class BPKeys(enum.Enum):
+    """
+    Mapping from user-visible name to database key for beam parameters.
+    """
+    id = "id"
+    name_ = "name"
+    beamline = "beamline"
+    nbc_range = "nBeamClassRange"
+    nev_range = "neVRange"
+    ntran = "nTran"
+    nrate = "nRate"
+    aperture_name = "ap_name"
+    y_gap = "ap_ygap"
+    y_center = "ap_ycenter"
+    x_gap = "ap_xgap"
+    x_center = "ap_xcenter"
+    damage_limit = "damage_limit"
+    pulse_energy = "pulse_energy"
+    notes = "notes"
+    special = "special"
+
+
+@dataclasses.dataclass(frozen=True)
+class BeamParameters:
+    """
+    Struct representation of one state's beam parameters.
+
+    The raw data has most of these as strings, but to make the struct
+    here we'll convert them to the most natural data types for
+    comparisons and add additional helpful fields for
+    human readability.
+
+    The same names as used in the web application are used here,
+    but all lowercase and with spaces replaced with underscores.
+    """
+    id: int
+    name: str
+    beamline: str
+    nbc_range: int
+    nbc_range_mask: str
+    nbc_range_desc: str
+    nev_range: int
+    nev_range_mask: str
+    nev_range_desc: str
+    ntran: float
+    nrate: int
+    aperture_name: str
+    y_gap: float
+    y_center: float
+    x_gap: float
+    x_center: float
+    damage_limit: str
+    pulse_energy: str
+    notes: str
+    special: bool
+
+    @classmethod
+    def from_raw(cls: type[T], data: RawStateBeamParams) -> T:
+        return cls(
+            id=data[BPKeys.id],
+            name=data[BPKeys.name_],
+            beamline=data[BPKeys.beamline],
+            nbc_range=int(data[BPKeys.nbc_range]),
+            nbc_range_mask=data[BPKeys.nbc_range],
+            nbc_range_desc=summarize_beam_class_bitmask(int(data[BPKeys.nbc_range])),
+            nev_range=int(data[BPKeys.nev_range]),
+            nev_range_mask=data[BPKeys.nev_range],
+            nev_range_desc=get_bitmask_desc(data[BPKeys.nev_range]),
+            ntran=float(data[BPKeys.ntran]),
+            aperture_name=data[BPKeys.aperture_name],
+            y_gap=float(data[BPKeys.y_gap]),
+            y_center=float(data[BPKeys.y_center]),
+            x_gap=float(data[BPKeys.x_gap]),
+            x_center=float(data[BPKeys.x_center]),
+            damage_limit=data[BPKeys.damage_limit],
+            pulse_energy=data[BPKeys.pulse_energy],
+            notes=data[BPKeys.notes],
+            special=data[BPKeys.special],
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class DeviceBeamParams:
+    """
+    The beam parameters associated with one device.
+
+    One device may have an arbitrary number of states.
+    """
+    device_name: str
+    state_beam_params: dict[str, BeamParameters]
+
+    @classmethod
+    def from_raw(cls: type[T], device_name: str, data: RawDeviceBeamParams) -> T:
+        return cls(
+            device_name=device_name,
+            state_beam_params={
+                key: BeamParameters.from_raw(value)
+                for key, value in data.items()
+            }
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class FileContents:
+    """
+    The contents of one file.
+
+    Each file is associated with exactly one plc hostname
+    and can contain an arbitrary number of devices.
+    """
+    plc_name: str
+    device_beam_params: dict[str, DeviceBeamParams]
+
+    @classmethod
+    def from_raw(cls: type[T], data: RawFileContents) -> T:
+        return cls(
+            plc_name=next(data.keys()),
+            device_beam_params={
+                key: DeviceBeamParams.from_raw(key, value)
+                for key, value in data.items()
+            }
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class FileInfo:
+    """
+    Generalized file info.
+
+    The fields are based on *nix systems, but this will
+    also be used for windows systems too.
+
+    This class has no constructor helpers here.
+    Each data source will need to implement a unique
+    constructor for this.
+    """
+    filename: str
+    directory: str
+    server: str
+    is_directory: bool
+    permissions: str
+    links: int
+    user: str
+    group: str
+    size: int
+    last_changed: datetime.datetime
+    raw_contents: RawFileContents
+    contents: FileContents

--- a/pmpsdb_client/ftp_data.py
+++ b/pmpsdb_client/ftp_data.py
@@ -230,7 +230,9 @@ def upload_filename(
     hostname : str
         The plc hostname to upload to.
     filename : str
-        The name of the file on both your filesystem and on the PLC.
+        The name of the file on your filesystem.
+    dest_filename : str, optional
+        The name of the file on the PLC. If omitted, same as filename.
     directory : str, optional
         The ftp subdirectory to read and write from
         A default directory pmps is used if this argument is omitted.

--- a/pmpsdb_client/ftp_data.py
+++ b/pmpsdb_client/ftp_data.py
@@ -49,7 +49,7 @@ def ftp(hostname: str, directory: str | None = None) -> Iterator[ftplib.FTP]:
     # Default directory
     directory = directory or DIRECTORY
     # Create without connecting
-    ftp_obj = ftplib.FTP(hostname, timeout=2.0)
+    ftp_obj = ftplib.FTP(hostname, timeout=1.0)
     # Beckhoff docs recommend active mode
     ftp_obj.set_pasv(False)
     # Best-effort login using default passwords

--- a/pmpsdb_client/ftp_data.py
+++ b/pmpsdb_client/ftp_data.py
@@ -94,7 +94,7 @@ def list_filenames(
     Parameters
     ----------
     hostname : str
-        The plc hostname to upload to.
+        The plc hostname to check.
     directory : str, optional
         The ftp subdirectory to read and write from
         A default directory pmps is used if this argument is omitted.

--- a/pmpsdb_client/gui.py
+++ b/pmpsdb_client/gui.py
@@ -28,9 +28,9 @@ from qtpy.QtWidgets import (QAction, QDialog, QFileDialog, QInputDialog,
 
 from .beam_class import summarize_beam_class_bitmask
 from .export_data import ExportFile, get_export_dir, get_latest_exported_files
-from .ftp_data import (download_file_json_dict, download_file_text,
-                       list_file_info, upload_filename)
 from .ioc_data import AllStateBP, PLCDBControls
+from .plc_data import (download_file_json_dict, download_file_text,
+                       list_file_info, upload_filename)
 
 logger = logging.getLogger(__name__)
 
@@ -578,7 +578,10 @@ class SummaryTables(DesignerDisplay, QWidget):
         filename = hostname_to_filename(hostname)
         for file_info in info:
             if file_info.filename == filename:
-                text = file_info.create_time.ctime()
+                try:
+                    text = file_info.create_time.ctime()
+                except AttributeError:
+                    text = file_info.last_changed.ctime()
                 break
         self.plc_table.item(row, PLCTableColumns.UPLOAD).setText(text)
         if update_export:

--- a/pmpsdb_client/gui.py
+++ b/pmpsdb_client/gui.py
@@ -578,10 +578,7 @@ class SummaryTables(DesignerDisplay, QWidget):
         filename = hostname_to_filename(hostname)
         for file_info in info:
             if file_info.filename == filename:
-                try:
-                    text = file_info.create_time.ctime()
-                except AttributeError:
-                    text = file_info.last_changed.ctime()
+                text = file_info.last_changed.ctime()
                 break
         self.plc_table.item(row, PLCTableColumns.UPLOAD).setText(text)
         if update_export:

--- a/pmpsdb_client/plc_data.py
+++ b/pmpsdb_client/plc_data.py
@@ -1,0 +1,7 @@
+"""
+Get file info from, upload files to, and download files from the PLCs.
+
+This calls methods from ssh_data and ftp_data as appropriate.
+When the system is configured correctly, exactly one of these submodules
+should work for getting data from the PLC.
+"""

--- a/pmpsdb_client/plc_data.py
+++ b/pmpsdb_client/plc_data.py
@@ -13,6 +13,7 @@ import logging
 from typing import Any
 
 from . import ftp_data, ssh_data
+from .data_types import FileInfo
 
 logger = logging.getLogger(__name__)
 plc_mapping: dict[str, DataMethod] = {}
@@ -39,7 +40,7 @@ def get_data_method(hostname: str, directory: str | None = None) -> DataMethod:
 def list_file_info(
     hostname: str,
     directory: str | None = None,
-) -> list[ssh_data.FileInfo | ftp_data.PLCFile]:
+) -> list[FileInfo]:
     """
     Get information about the files that are currently saved on the PLC.
 
@@ -54,7 +55,7 @@ def list_file_info(
 
     Returns
     -------
-    filenames : list of FileInfo or PLCFile
+    filenames : list of FileInfo
         Information about all the files in the PLC's pmps folder.
     """
     try:

--- a/pmpsdb_client/plc_data.py
+++ b/pmpsdb_client/plc_data.py
@@ -77,6 +77,7 @@ def list_file_info(
             try:
                 file_info = ftp_data.list_file_info(hostname=hostname, directory=directory)
             except Exception:
+                logger.debug("ftp failed too, maybe %s is offline or not set up", hostname)
                 raise RuntimeError(f"Cannot get data method for {hostname}")
             else:
                 logger.debug("Cache %s method as ftp", hostname)

--- a/pmpsdb_client/plc_data.py
+++ b/pmpsdb_client/plc_data.py
@@ -79,7 +79,7 @@ def list_file_info(
                 file_info = ftp_data.list_file_info(hostname=hostname, directory=directory)
             except Exception:
                 logger.debug("ftp failed too, maybe %s is offline or not set up", hostname)
-                raise RuntimeError(f"Cannot get data method for {hostname}")
+                raise RuntimeError(f"Cannot connect to {hostname}")
             else:
                 logger.debug("Cache %s method as ftp", hostname)
                 plc_mapping[hostname] = DataMethod.ftp

--- a/pmpsdb_client/plc_data.py
+++ b/pmpsdb_client/plc_data.py
@@ -63,21 +63,27 @@ def list_file_info(
         data_method = DataMethod.unk
 
     if data_method == DataMethod.ssh:
+        logger.debug("Using cached ssh method to list files for %s", hostname)
         return ssh_data.list_file_info(hostname=hostname, directory=directory)
     elif data_method == DataMethod.ftp:
+        logger.debug("Using cached ftp method to list files for %s", hostname)
         return ftp_data.list_file_info(hostname=hostname, directory=directory)
     elif data_method == DataMethod.unk:
+        logger.debug("Connection method unknown, check if ssh method works for %s", hostname)
         try:
             file_info = ssh_data.list_file_info(hostname=hostname, directory=directory)
         except Exception:
+            logger.debug("ssh failed, check if ftp method works for %s", hostname)
             try:
                 file_info = ftp_data.list_file_info(hostname=hostname, directory=directory)
             except Exception:
                 raise RuntimeError(f"Cannot get data method for {hostname}")
             else:
+                logger.debug("Cache %s method as ftp", hostname)
                 plc_mapping[hostname] = DataMethod.ftp
                 return file_info
         else:
+            logger.debug("Cache %s method as ssh", hostname)
             plc_mapping[hostname] = DataMethod.ssh
             return file_info
     else:

--- a/pmpsdb_client/plc_data.py
+++ b/pmpsdb_client/plc_data.py
@@ -97,7 +97,7 @@ def upload_filename(
     filename: str,
     dest_filename: str | None = None,
     directory: str | None = None,
-):
+) -> None:
     """
     Open and upload a file on your filesystem to a PLC.
 
@@ -110,7 +110,7 @@ def upload_filename(
     dest_filename : str, optional
         The name of the file on the PLC. If omitted, same as filename.
     directory : str, optional
-        The ssh subdirectory to read and write from
+        The subdirectory to read and write from
         A default directory is used if this argument is omitted,
         which depends on the PLC OS.
     """
@@ -151,8 +151,9 @@ def download_file_text(
     filename : str
         The name of the file on the PLC.
     directory : str, optional
-        The ssh subdirectory to read and write from
-        A default directory /home/ecs-user/pmpsdb is used if this argument is omitted.
+        The subdirectory to read and write from
+        A default directory is used if this argument is omitted,
+        which depends on the PLC OS.
 
     Returns
     -------
@@ -194,8 +195,9 @@ def download_file_json_dict(
     filename : str
         The name of the file on the PLC.
     directory : str, optional
-        The ftp subdirectory to read and write from
-        A default directory pmps is used if this argument is omitted.
+        The subdirectory to read and write from
+        A default directory is used if this argument is omitted,
+        which depends on the PLC OS.
 
     Returns
     -------
@@ -257,8 +259,9 @@ def compare_file(
         The filename as saved on the PLC. If omitted, the local_filename's
         basename will be used.
     directory : str, optional
-        The ftp subdirectory to read and write from
-        A default directory pmps is used if this argument is omitted.
+        The subdirectory to read and write from
+        A default directory is used if this argument is omitted,
+        which depends on the PLC OS.
 
     Returns
     -------

--- a/pmpsdb_client/plc_data.py
+++ b/pmpsdb_client/plc_data.py
@@ -5,3 +5,258 @@ This calls methods from ssh_data and ftp_data as appropriate.
 When the system is configured correctly, exactly one of these submodules
 should work for getting data from the PLC.
 """
+from __future__ import annotations
+
+import enum
+import json
+import logging
+from typing import Any
+
+from . import ftp_data, ssh_data
+
+logger = logging.getLogger(__name__)
+plc_mapping: dict[str, DataMethod] = {}
+
+
+class DataMethod(enum.Enum):
+    ssh = enum.auto()
+    ftp = enum.auto()
+
+
+def get_data_method(hostname: str, directory: str | None = None) -> DataMethod:
+    try:
+        return plc_mapping[hostname]
+    except KeyError:
+        ...
+    try:
+        ssh_data.list_file_info(hostname=hostname, directory=directory)
+    except Exception:
+        try:
+            ftp_data.list_file_info(hostname=hostname, directory=directory)
+        except Exception:
+            raise RuntimeError(f"Cannot get data method for {hostname}")
+        else:
+            plc_mapping[hostname] = DataMethod.ftp
+            return DataMethod.ftp
+    else:
+        plc_mapping[hostname] = DataMethod.ssh
+        return DataMethod.ssh
+
+
+def list_file_info(
+    hostname: str,
+    directory: str | None = None,
+) -> list[ssh_data.FileInfo | ftp_data.PLCFile]:
+    """
+    Get information about the files that are currently saved on the PLC.
+
+    Parameters
+    ----------
+    hostname : str
+        The plc hostname to check.
+    directory : str, optional
+        The diretory to read and write from.
+        A default directory is used if this argument is omitted,
+        which depends on the PLC OS.
+
+    Returns
+    -------
+    filenames : list of FileInfo or PLCFile
+        Information about all the files in the PLC's pmps folder.
+    """
+    data_method = get_data_method(hostname=hostname, directory=directory)
+    if data_method == DataMethod.ssh:
+        return ssh_data.list_file_info(hostname=hostname, directory=directory)
+    elif data_method == DataMethod.ftp:
+        return ftp_data.list_file_info(hostname=hostname, directory=directory)
+    else:
+        raise RuntimeError(f"Unhandled data method {data_method}")
+
+
+def upload_filename(
+    hostname: str,
+    filename: str,
+    dest_filename: str | None = None,
+    directory: str | None = None,
+):
+    """
+    Open and upload a file on your filesystem to a PLC.
+
+    Parameters
+    ----------
+    hostname : str
+        The plc hostname to upload to.
+    filename : str
+        The name of the file on your filesystem.
+    dest_filename : str, optional
+        The name of the file on the PLC. If omitted, same as filename.
+    directory : str, optional
+        The ssh subdirectory to read and write from
+        A default directory is used if this argument is omitted,
+        which depends on the PLC OS.
+    """
+    data_method = get_data_method(hostname=hostname, directory=directory)
+    if data_method == DataMethod.ssh:
+        return ssh_data.upload_filename(
+            hostname=hostname,
+            filename=filename,
+            dest_filename=dest_filename,
+            directory=directory,
+        )
+    elif data_method == DataMethod.ftp:
+        return ftp_data.upload_filename(
+            hostname=hostname,
+            filename=filename,
+            dest_filename=dest_filename,
+            directory=directory,
+        )
+    else:
+        raise RuntimeError(f"Unhandled data method {data_method}")
+
+
+def download_file_text(
+    hostname: str,
+    filename: str,
+    directory: str | None = None,
+) -> str:
+    """
+    Download a file from the PLC to use in Python.
+
+    The result is a single string, suitable for operations like
+    json.loads
+
+    Parameters
+    ----------
+    hostname : str
+        The plc hostname to download from.
+    filename : str
+        The name of the file on the PLC.
+    directory : str, optional
+        The ssh subdirectory to read and write from
+        A default directory /home/ecs-user/pmpsdb is used if this argument is omitted.
+
+    Returns
+    -------
+    text: str
+        The contents from the file.
+    """
+    data_method = get_data_method(hostname=hostname, directory=directory)
+    if data_method == DataMethod.ssh:
+        return ssh_data.download_file_text(
+            hostname=hostname,
+            filename=filename,
+            directory=directory,
+        )
+    elif data_method == DataMethod.ftp:
+        return ftp_data.download_file_text(
+            hostname=hostname,
+            filename=filename,
+            directory=directory,
+        )
+    else:
+        raise RuntimeError(f"Unhandled data method {data_method}")
+
+
+def download_file_json_dict(
+    hostname: str,
+    filename: str,
+    directory: str | None = None,
+) -> dict[str, dict[str, Any]]:
+    """
+    Download a file from the PLC and interpret it as a json dictionary.
+
+    The result is suitable for comparing to json blobs exported from the
+    pmps database.
+
+    Parameters
+    ----------
+    hostname : str
+        The plc hostname to download from.
+    filename : str
+        The name of the file on the PLC.
+    directory : str, optional
+        The ftp subdirectory to read and write from
+        A default directory pmps is used if this argument is omitted.
+
+    Returns
+    -------
+    data : dict
+        The dictionary data from the file stored on the plc.
+    """
+    logger.debug(
+        'download_file_json_dict(%s, %s, %s)',
+        hostname,
+        filename,
+        directory,
+    )
+    return json.loads(
+        download_file_text(
+            hostname=hostname,
+            filename=filename,
+            directory=directory,
+        )
+    )
+
+
+def local_file_json_dict(filename: str) -> dict[str, dict[str, Any]]:
+    """
+    Return the json dict from a local file.
+
+    Suitable for comparisons to files from the database or from the plc.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file on the local filesystem.
+
+    Returns
+    -------
+    data : dict
+        The dictionary data from the file stored on the local drive.
+    """
+    logger.debug('local_file_json_dict(%s)', filename)
+    with open(filename, 'r') as fd:
+        return json.load(fd)
+
+
+def compare_file(
+    hostname: str,
+    local_filename: str,
+    plc_filename: str | None = None,
+    directory: str | None = None,
+) -> bool:
+    """
+    Compare a file saved locally to one on the PLC.
+
+    Parameters
+    ----------
+    hostname : str
+        The plc hostname to download from.
+    local_filename: str
+        The full path the local file to compare with.
+    plc_filename: str, optional
+        The filename as saved on the PLC. If omitted, the local_filename's
+        basename will be used.
+    directory : str, optional
+        The ftp subdirectory to read and write from
+        A default directory pmps is used if this argument is omitted.
+
+    Returns
+    -------
+    same_file : bool
+        True if the contents of these two files are the same.
+    """
+    logger.debug(
+        'compare_file(%s, %s, %s, %s)',
+        hostname,
+        local_filename,
+        plc_filename,
+        directory,
+    )
+    local_data = local_file_json_dict(filename=local_filename)
+    plc_data = download_file_json_dict(
+        hostname=hostname,
+        filename=plc_filename,
+        directory=directory,
+    )
+    return local_data == plc_data

--- a/pmpsdb_client/pmpsdb_tst.yml
+++ b/pmpsdb_client/pmpsdb_tst.yml
@@ -1,3 +1,5 @@
+plc-tst-bsd1: "PLC:TST:BSD1"
+plc-tst-bsd2: "PLC:TST:BSD2"
 plc-tst-motion: "PLC:TST:MOT"
 plc-tst-pmps-subsytem-a: "PLC:TST:PMPS:A"
 plc-tst-pmps-subsytem-b: "PLC:TST:PMPS:B"

--- a/pmpsdb_client/ssh_data.py
+++ b/pmpsdb_client/ssh_data.py
@@ -76,17 +76,16 @@ class FileInfo:
     last_changed: datetime.datetime
     filename: str
 
-    @classmethod
-    def get_output_lines(cls, conn: Connection) -> str:
+    @staticmethod
+    def get_output_lines(conn: Connection) -> str:
         return conn.run("ls -l -D %s", hide=True).stdout
 
     @classmethod
-    def from_all_output_lines(cls: T, output_lines) -> list[T]:
+    def from_all_output_lines(cls: type[T], output_lines) -> list[T]:
         return [cls.from_output_line(line) for line in output_lines.strip().split("\n")[1:]]
 
     @classmethod
-    def from_output_line(cls: T, output: str) -> T:
-        print(output)
+    def from_output_line(cls: type[T], output: str) -> T:
         type_perms, links, user, group, size, date, filename = output.strip().split()
 
         return cls(
@@ -101,7 +100,7 @@ class FileInfo:
         )
 
 
-def get_file_info(
+def list_file_info(
     hostname: str,
     directory: typing.Optional[str] = None,
 ) -> list[FileInfo]:

--- a/pmpsdb_client/ssh_data.py
+++ b/pmpsdb_client/ssh_data.py
@@ -54,6 +54,7 @@ def ssh(
             host=hostname,
             user=user,
             config=Config(ssh_config=SSHConfig.from_text(SSH_CONFIG)),
+            connect_timeout=1,
             connect_kwargs={
                 "password": pw,
                 "allow_agent": False,

--- a/pmpsdb_client/ssh_data.py
+++ b/pmpsdb_client/ssh_data.py
@@ -14,6 +14,8 @@ from io import StringIO
 from typing import Iterator, TypeVar
 
 from fabric import Connection
+from fabric.config import Config
+from paramiko.config import SSHConfig
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +23,13 @@ DEFAULT_PW = (
     ("ecs-user", "1"),
 )
 DIRECTORY = "/home/{user}/pmpsdb"
+SSH_CONFIG = """
+Host *
+    ForwardAgent no
+    ForwardX11 no
+    ForwardX11Trusted no
+    PreferredAuthentications=password
+"""
 
 T = TypeVar("T")
 
@@ -43,7 +52,11 @@ def ssh(
         with Connection(
             host=hostname,
             user=user,
-            connect_kwargs={"password": pw}
+            config=Config(ssh_config=SSHConfig.from_text(SSH_CONFIG)),
+            connect_kwargs={
+                "password": pw,
+                "allow_agent": False,
+            },
         ) as conn:
             try:
                 conn.open()

--- a/pmpsdb_client/ssh_data.py
+++ b/pmpsdb_client/ssh_data.py
@@ -10,7 +10,7 @@ import datetime
 import logging
 from contextlib import contextmanager
 from dataclasses import dataclass
-from io import StringIO
+from io import BytesIO
 from pathlib import Path
 from typing import Iterator, TypeVar
 
@@ -203,9 +203,9 @@ def download_file_text(
         The contents from the file.
     """
     logger.debug("download_file_text(%s, %s, %s)", hostname, filename, directory)
-    stringio = StringIO()
+    bytesio = BytesIO()
     with ssh(hostname=hostname, directory=directory) as conn:
         if directory is None:
             directory = conn.cwd
-        conn.get(remote=str(Path(directory) / filename), local=stringio)
-    return stringio.getvalue()
+        conn.get(remote=str(Path(directory) / filename), local=bytesio)
+    return bytesio.getvalue().decode(encoding="utf-8")

--- a/pmpsdb_client/ssh_data.py
+++ b/pmpsdb_client/ssh_data.py
@@ -1,0 +1,84 @@
+"""
+Module to define the scp transfer interface for the TCBSD PLCs.
+
+This is how we upload database files to and download database files from the
+PLCs.
+"""
+from __future__ import annotations
+
+import logging
+import typing
+from contextlib import contextmanager
+
+from fabric import Connection
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PW = (
+    ("Administrator", "1"),
+)
+DIRECTORY = "/Hard Disk/ftp/pmps"
+
+
+@contextmanager
+def ssh(
+    hostname: str,
+    directory: typing.Optional[str] = None,
+) -> Connection:
+    """
+    Context manager to handle a single ssh connection.
+
+    Within one connection we can do any number of remote operations on the
+    TCBSD PLC.
+    """
+    directory = directory or DIRECTORY
+    connected = False
+    excs = []
+
+    for user, pw in DEFAULT_PW:
+        with Connection(
+            host=hostname,
+            user=user,
+            connect_kwargs={"password": pw}
+        ) as conn:
+            try:
+                conn.open()
+            except Exception as exc:
+                excs.append(exc)
+                continue
+            connected = True
+            with conn.cd(directory):
+                yield conn
+    if not connected:
+        if len(excs) > 1:
+            raise RuntimeError(excs)
+        elif excs:
+            raise excs[0]
+        else:
+            raise RuntimeError("Unable to connect to PLC")
+
+
+def list_filenames(
+    hostname: str,
+    directory: typing.Optional[str] = None,
+) -> list[str]:
+    """
+    List the filenames that are currently saved on the PLC.
+
+    Parameters
+    ----------
+    hostname : str
+        The plc hostname to check.
+    directory : str, optional
+        The diretory to read and write from.
+        A default directory pmps is used if this argument is omitted.
+
+    Returns
+    -------
+    filenames : list of str
+        The filenames on the PLC.
+    """
+    logger.debug("list_filenames(%s, %s)", hostname, directory)
+    with ssh(hostname=hostname, directory=directory) as conn:
+        output = conn.run("ls", hide=True).stdout
+    return output.strip().split("\n")

--- a/pmpsdb_client/ssh_data.py
+++ b/pmpsdb_client/ssh_data.py
@@ -68,8 +68,8 @@ class FileInfo:
     File information from *nix systems.
     """
     is_directory: bool
-    links: int
     permissions: str
+    links: int
     user: str
     group: str
     size: int

--- a/pmpsdb_client/ssh_data.py
+++ b/pmpsdb_client/ssh_data.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 
 import datetime
 import logging
-import typing
 from contextlib import contextmanager
 from dataclasses import dataclass
 from io import StringIO
+from typing import Iterator, TypeVar
 
 from fabric import Connection
 
@@ -22,14 +22,14 @@ DEFAULT_PW = (
 )
 DIRECTORY = "/home/{user}/pmpsdb"
 
-T = typing.TypeVar("T")
+T = TypeVar("T")
 
 
 @contextmanager
 def ssh(
     hostname: str,
-    directory: typing.Optional[str] = None,
-) -> typing.Iterator[Connection]:
+    directory: str | None = None,
+) -> Iterator[Connection]:
     """
     Context manager to handle a single ssh connection.
 
@@ -106,7 +106,7 @@ class FileInfo:
 
 def list_file_info(
     hostname: str,
-    directory: typing.Optional[str] = None,
+    directory: str | None = None,
 ) -> list[FileInfo]:
     """
     Get information about the files that are currently saved on the PLC.
@@ -133,8 +133,8 @@ def list_file_info(
 def upload_filename(
     hostname: str,
     filename: str,
-    dest_filename: typing.Optional[str] = None,
-    directory: typing.Optional[str] = None,
+    dest_filename: str | None = None,
+    directory: str | None = None,
 ):
     """
     Open and upload a file on your filesystem to a PLC.
@@ -161,7 +161,7 @@ def upload_filename(
 def download_file_text(
     hostname: str,
     filename: str,
-    directory: typing.Optional[str] = None,
+    directory: str | None = None,
 ) -> str:
     """
     Download a file from the PLC to use in Python.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ pcdscalc
 pcdsutils
 prettytable
 qtpy
-setuptools-scm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+fabric
 ophyd
 pcdscalc
 pcdsutils


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Big idea: we can upload files to and download files from the TcBSD PLCs using scp instead of ftp, which is more modern and secure and is enabled by default on these. The old ftp support stays for backwards compatibility, because the old PLCs cannot use ssh/scp.

Main changes:
- `ssh_data` has been added with a similar API to `ftp_data`, but it uses ssh/scp as the transport mechanism.
- `plc_data` has been added, which imports from `ftp_data` and `ssh_data` and picks the method to use. It does this by trying ssh, and then trying ftp if ssh fails, and caching which one succeeded for next time.
- `data_types` has been added, which currently generalizes the file info from each data source so that functions that may expect either can do type checking. In the future this may also have structs to help give us more detailed pmps parameter comparisons. This also required me to rename `created_time` -> `modified_time` to more accurately support both ssh and ftp at the same time.
- The `cli` and `gui` modules will import from `plc_data` instead of from `ftp_data` and are otherwise unchanged.
- Relocate helper functions without direct relations to ftp from `ftp_data` to `plc_data`
- Add `fabric` as a runtime dependency for the ssh/scp data transfer.

Other changes:
- Remove PyQt5 from the ci testing extras in favor of the more general dev-requirements.txt file. This is the new place we're keeping the requirements, so that they are noticed when checked outside of the CI builds.
- Create a conda recipe for the repo to use for the CI builds.
- Make the debug logger show timestamps, make the non-debug logger ignore paramiko spam
- General cleanup of docstrings and type annotations
- Decrease data timeouts from 2s to 1s to help with long chain timeouts, especially in the gui
- Add more test PLCs to the tst config
- Remove `setuptools-scm` as a runtime dependency because it is not used at runtime.

Some remaining sloppiness:
- [x] There isn't 1:1 parity between the data structures in the ftp module vs the data structures in the ssh module. Some of this is intrinsic to the difference between the protocols, but some of it is simply messy and it could be cleaned up. This leads to some unsightly bifurcations elsewhere in the code. (resolved: make them more similar and clean up)
- [x] I made a `data_types` module last year (?) and then didn't use it anywhere. I think I was intending to augment the comparison operations but I never implemented anything further. I should probably delete it or banish it to its own branch. (resolved: remove unused elements from data_types, keep the ones useful for comparing files between PLCs)
- [ ] The CI fails because the standard CI expects there to be an automatic docs build, but these are not present in this repo. (unresolved: make the CI not require the docs build and handle this later)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See above, but largely: scp is more secure and is enabled by default on the new PLCs. The rest of the code doesn't have to change very much to accommodate new data transfer methodologies.

Related to:
https://github.com/pcdshub/lcls-twincat-motion/pull/215
https://github.com/pcdshub/twincat-bsd-ansible/pull/19

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Setup for the ecs-user account is documented on this page: https://confluence.slac.stanford.edu/display/PCDS/TcBSD+PLC+Setup

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] Pre-commit passes on GitHub Actions
