### PR TITLE
Adding dream motion

### DIFF
--- a/pmpsdb_client/pmpsdb_tmo.yml
+++ b/pmpsdb_client/pmpsdb_tmo.yml
@@ -1,2 +1,3 @@
 plc-tmo-motion: "PLC:TMO:MOTION"
 plc-tmo-optics: "PLC:TMO:OPTICS"
+plc-dream-motion: "PLC:lcls_dream_motion"


### PR DESCRIPTION
Requested in https://jira.slac.stanford.edu/browse/ECS-8182.

plc-dream-mtoion is a bsd plc and I was able to login as ecs-user with password 1, so I guess there are no other settings to allow exports?

![image](https://github.com/user-attachments/assets/1c887bd3-1489-412c-ae31-e12f9ffd2ae6)
